### PR TITLE
Adjust the comment for API.unregisterPlatformAccessories

### DIFF
--- a/src/docs/api/platform-plugins.md
+++ b/src/docs/api/platform-plugins.md
@@ -72,7 +72,7 @@ class ExamplePlatformPlugin {
 
     /**
      * Platforms should wait until the "didFinishLaunching" event has fired before
-     * registering any new accessories.
+     * unregistering any accessories.
      */
     api.on('didFinishLaunching', () => {
       // for the example just remove the first restored cached accessory


### PR DESCRIPTION
The comment in the example code for the `API.unregisterPlatformAccessories` reference doesn't really reflect the situation in the example.

The comment was updated to better reflect the situation.