### PR TITLE
Fix typo

### DIFF
--- a/src/docs/api/service.md
+++ b/src/docs/api/service.md
@@ -32,7 +32,7 @@ Updates the characteristic value. This can be used to update the state of a char
 service.updateCharacteristic(Characteristic.Brightness, 60);
 ```
 
-Can also be used to mark a service/accessory as 'Not Responding' in the Home App by returning an error object instead of a valid value.  Only needs to be set on a single/primary charactertic of an accessory, and needs to be updated with a valid value when the accessory is available again.  The error message text is for internal use only, and is not passed to the Home App. 
+Can also be used to mark a service/accessory as 'Not Responding' in the Home App by returning an error object instead of a valid value.  Only needs to be set on a single/primary characteristic of an accessory, and needs to be updated with a valid value when the accessory is available again.  The error message text is for internal use only, and is not passed to the Home App. 
 
 ```js
 service.updateCharacteristic(Characteristic.Brightness, new Error('A placeholder error object'));


### PR DESCRIPTION
charactertic -> characteristic

Note: Passing an error object to the function doesn't seem to be supported (anymore?) according to the latest Typescript definitions.